### PR TITLE
Fix error when checking for null values.

### DIFF
--- a/src/android/Operations.java
+++ b/src/android/Operations.java
@@ -1,0 +1,7 @@
+package org.sumaq.plugins.googlesheets;
+
+public abstract class Operations {
+  public boolean isCordovaNullable(String value) {
+    return (value == null || value == "null");
+  }
+}

--- a/src/android/SheetsOperations.java
+++ b/src/android/SheetsOperations.java
@@ -7,7 +7,7 @@ import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecovera
 import java.lang.Runnable;
 import org.json.JSONArray;
 
-public class SheetsOperations {
+public class SheetsOperations extends Operations {
   private GoogleSheets mPlugin;
   private static SheetsOperations mInstance;
 

--- a/src/android/SpreadsheetsOperations.java
+++ b/src/android/SpreadsheetsOperations.java
@@ -10,7 +10,7 @@ import java.lang.Runnable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SpreadsheetsOperations {
+public class SpreadsheetsOperations extends Operations {
   private GoogleSheets mPlugin;
   private static SpreadsheetsOperations mInstance;
 
@@ -48,19 +48,19 @@ public class SpreadsheetsOperations {
           SpreadsheetProperties properties = new SpreadsheetProperties();
           Sheets sheetsService = mPlugin.getService();
 
-          if (spreadsheetTitle != null && spreadsheetTitle != "null") {
+          if (!isCordovaNullable(spreadsheetTitle)) {
             properties.setTitle(spreadsheetTitle);
           }
 
-          if (spreadsheetLocale != null && spreadsheetLocale != "null") {
+          if (!isCordovaNullable(spreadsheetLocale)) {
             properties.setLocale(spreadsheetLocale);
           }
 
-          if (spreadsheetAutoRecalc != null && spreadsheetLocale != "null") {
+          if (!isCordovaNullable(spreadsheetAutoRecalc)) {
             properties.setAutoRecalc(spreadsheetAutoRecalc);
           }
           
-          if (spreadsheetTimeZone != null && spreadsheetTimeZone != "null") {
+          if (!isCordovaNullable(spreadsheetTimeZone)) {
             properties.setTimeZone(spreadsheetTimeZone);
           }
 

--- a/src/android/ValuesOperations.java
+++ b/src/android/ValuesOperations.java
@@ -18,7 +18,7 @@ import java.util.List;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-public class ValuesOperations {
+public class ValuesOperations extends Operations {
   private GoogleSheets mPlugin;
   private static ValuesOperations mInstance;
   public static String STR_DEFAULT_MAJOR_DIMENSION_OPT = "ROWS";
@@ -64,10 +64,10 @@ public class ValuesOperations {
           Sheets sheetsService = mPlugin.getService();
           Sheets.Spreadsheets.Values.Append request =
               sheetsService.spreadsheets().values().append(spreadsheetId, range, requestBody);
-          if (valueInputOption == null || valueInputOption == "null") {
+          if (!isCordovaNullable(valueInputOption)) {
             valueInputOption = ValuesOperations.DEFAULT_VALUE_INPUT_OPTION;
           }
-          if (insertDataOption == null || insertDataOption == "null") {
+          if (!isCordovaNullable(insertDataOption)) {
             insertDataOption = ValuesOperations.DEFAULT_INSERT_DATA_OPTION;
           }
           request.setValueInputOption(valueInputOption);
@@ -146,10 +146,10 @@ public class ValuesOperations {
           Sheets.Spreadsheets.Values.BatchGet request =
               sheetsService.spreadsheets().values().batchGet(spreadsheetId);
           request.setRanges(rangesList);
-          if (valueRenderOption != null) {
+          if (!isCordovaNullable(valueRenderOption)) {
             request.setValueRenderOption(valueRenderOption);
           }
-          if (dateTimeRenderOption != null) {
+          if (!isCordovaNullable(dateTimeRenderOption)) {
             request.setDateTimeRenderOption(dateTimeRenderOption);
           }
           BatchGetValuesResponse response = request.execute();


### PR DESCRIPTION
There was a problem when trying to find out whether a parameter passed
down from the cordova javascript interface was whether a null String
object or a String object containing the word "null".

This has been solved by adding a mechanism to chec for both cases, since
the documentation on apache cordova is not that clear about that matter.