### PR TITLE
Make calls to CallbackContext object thread safe

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -27,10 +27,13 @@
       <uses-permission android:name="android.permission.USE_CREDENTIALS" />
     </config-file>
     <source-file src="src/android/GoogleSheets.java" target-dir="src/org/sumaq/plugins/googlesheets" />
-    <source-file src="src/android/Operations.java" target-dir="src/org/sumaq/plugins/googlesheets" />
+    <source-file src="src/android/OperationsProvider.java" target-dir="src/org/sumaq/plugins/googlesheets" />
+    <source-file src="src/android/Operation.java" target-dir="src/org/sumaq/plugins/googlesheets" />
+    <source-file src="src/android/AccountOperations.java" target-dir="src/org/sumaq/plugins/googlesheets" />
     <source-file src="src/android/SheetsOperations.java" target-dir="src/org/sumaq/plugins/googlesheets" />
     <source-file src="src/android/ValuesOperations.java" target-dir="src/org/sumaq/plugins/googlesheets" />
     <source-file src="src/android/SpreadsheetsOperations.java" target-dir="src/org/sumaq/plugins/googlesheets" />
+    <source-file src="src/android/UserNotSignedIn.java" target-dir="src/org/sumaq/plugins/googlesheets" />
     <config-file parent="/*" target="res/values/strings.xml">
       <string name="google_play_services_request">%1$s requires Google Play Services. Please Install Google Play Services on your device and relaunch the app.
       </string>

--- a/src/android/AccountOperations.java
+++ b/src/android/AccountOperations.java
@@ -1,0 +1,150 @@
+package org.sumaq.plugins.googlesheets;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.pm.ApplicationInfo;
+import com.google.api.client.extensions.android.http.AndroidHttp;
+import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.util.ExponentialBackOff;
+import com.google.api.services.sheets.v4.Sheets;
+import java.util.Arrays;
+import org.apache.cordova.CallbackContext;
+
+public class AccountOperations extends OperationsProvider {
+  public static final String ACCOUNT_PERMISSION_INTERRUPTED = "accountPermissionInterrupted";
+  private static final String PREF_ACCOUNT_NAME = "accountName";
+  private static AccountOperations mInstance;
+  private GoogleSheets mPlugin;
+  private GoogleAccountCredential mCredential;
+  private String mApplicationName;
+  private String mAccountName;
+  private Activity mActivity;
+  private com.google.api.services.sheets.v4.Sheets mService = null;
+
+  private AccountOperations(GoogleSheets plugin) {
+    mPlugin = plugin;
+
+    mApplicationName =
+        mApplicationName == null
+            ? getApplicationName(mPlugin.getCordova().getActivity().getApplicationContext())
+            : "";
+
+    mAccountName =
+        mPlugin
+            .getCordova()
+            .getActivity()
+            .getPreferences(Context.MODE_PRIVATE)
+            .getString(PREF_ACCOUNT_NAME, null);
+
+    setCredential();
+
+    if (mAccountName != null && mAccountName != "") {
+      mCredential.setSelectedAccountName(mAccountName);
+      mService = buildClient();
+    }
+  }
+
+  private void setCredential() {
+    mCredential =
+        GoogleAccountCredential.usingOAuth2(
+                mPlugin.getCordova().getActivity().getApplicationContext(),
+                Arrays.asList(GoogleSheets.SCOPES))
+            .setBackOff(new ExponentialBackOff());
+  }
+
+  public static AccountOperations getInstance(GoogleSheets plugin) {
+    if (mInstance == null) {
+      mInstance = new AccountOperations(plugin);
+    }
+    return mInstance;
+  }
+
+  public Operation signIn(final CallbackContext callbackContext) {
+    return new Operation() {
+      CallbackContext context = callbackContext;
+
+      @Override
+      public void run() {
+        String accountName =
+            mPlugin
+                .getCordova()
+                .getActivity()
+                .getPreferences(Context.MODE_PRIVATE)
+                .getString(PREF_ACCOUNT_NAME, null);
+        if (accountName == null) {
+          if (mPlugin.hasAccountPermissions()) {
+            mPlugin.chooseAccount(this, callbackContext, mCredential.newChooseAccountIntent());
+          } else {
+            mPlugin.askForAccountPermission(this);
+          }
+        } else {
+          mCredential.setSelectedAccountName(accountName);
+          mService = buildClient();
+          callbackContext.success("signed in as " + mAccountName);
+        }
+      }
+
+      @Override
+      public void abort() {
+        context.error("Could not sign in");
+      }
+    };
+  }
+
+  public Operation isUserSignedIn(final CallbackContext callbackContext) {
+    return new Operation() {
+      @Override
+      public void run() {
+        String accountName = mCredential.getSelectedAccountName();
+        if (accountName != null && accountName.length() != 0) {
+          callbackContext.success(accountName);
+        } else {
+          callbackContext.error("No user signed in");
+        }
+      }
+    };
+  }
+
+  public Operation signOut(final CallbackContext callbackContext) {
+    return new Operation() {
+      @Override
+      public void run() {
+        String accountName = mCredential.getSelectedAccountName();
+        if (accountName != "" && accountName != null) {
+          setCredential();
+          mService = null;
+          callbackContext.success("Succesfully signed out");
+          SharedPreferences settings = mActivity.getPreferences(Context.MODE_PRIVATE);
+          SharedPreferences.Editor editor = settings.edit();
+          editor.putString(PREF_ACCOUNT_NAME, accountName);
+          editor.apply();
+        } else {
+          callbackContext.error("Already signed out");
+        }
+      }
+    };
+  }
+
+  public String getApplicationName(Context context) {
+    ApplicationInfo appInfo = context.getApplicationInfo();
+    int stringId = appInfo.labelRes;
+    return stringId == 0 ? appInfo.nonLocalizedLabel.toString() : context.getString(stringId);
+  }
+
+  private Sheets buildClient() {
+    return new com.google.api.services.sheets.v4.Sheets.Builder(
+            AndroidHttp.newCompatibleTransport(), JacksonFactory.getDefaultInstance(), mCredential)
+        .setApplicationName(mApplicationName)
+        .build();
+  }
+
+  public Sheets getService() throws UserNotSignedIn {
+    if (mService != null) {
+      return mService;
+    } else {
+      throw new UserNotSignedIn();
+    }
+  }
+}

--- a/src/android/Operation.java
+++ b/src/android/Operation.java
@@ -1,0 +1,17 @@
+package org.sumaq.plugins.googlesheets;
+
+import org.apache.cordova.CallbackContext;
+
+public abstract class Operation implements Runnable {
+  public static final String INTERRUPTED_OPERATION = "OPERATION_INTERRUPTED_OP";
+
+  private CallbackContext mContext;
+
+  public void run() {
+    mContext.success("Success!!!");
+  };
+
+  public void abort() {
+    mContext.error("Aborted");
+  };
+}

--- a/src/android/OperationsProvider.java
+++ b/src/android/OperationsProvider.java
@@ -1,6 +1,6 @@
 package org.sumaq.plugins.googlesheets;
 
-public abstract class Operations {
+public abstract class OperationsProvider {
   public boolean isCordovaNullable(String value) {
     return (value == null || value == "null");
   }

--- a/src/android/SheetsOperations.java
+++ b/src/android/SheetsOperations.java
@@ -3,11 +3,10 @@ package org.sumaq.plugins.googlesheets;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.CopySheetToAnotherSpreadsheetRequest;
 import com.google.api.services.sheets.v4.model.SheetProperties;
-import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException;
-import java.lang.Runnable;
+import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
 
-public class SheetsOperations extends Operations {
+public class SheetsOperations extends OperationsProvider {
   private GoogleSheets mPlugin;
   private static SheetsOperations mInstance;
 
@@ -22,8 +21,9 @@ public class SheetsOperations extends Operations {
     return mInstance;
   }
 
-  public Runnable copyTo(final JSONArray params) {
-    return new Runnable() {
+  public Operation copyTo(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -38,11 +38,9 @@ public class SheetsOperations extends Operations {
               sheetsService.spreadsheets().sheets().copyTo(spreadsheetId, sheetId, requestBody);
 
           SheetProperties response = request.execute();
-          mPlugin.getCallbackContext().success(response.toString());
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+          context.success(response.toString());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };

--- a/src/android/SpreadsheetsOperations.java
+++ b/src/android/SpreadsheetsOperations.java
@@ -1,16 +1,15 @@
 package org.sumaq.plugins.googlesheets;
 
-import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException;
 import com.google.api.services.sheets.v4.Sheets;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
 import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
-import org.json.JSONArray;
-import org.json.JSONObject;
-import java.lang.Runnable;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.cordova.CallbackContext;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
-public class SpreadsheetsOperations extends Operations {
+public class SpreadsheetsOperations extends OperationsProvider {
   private GoogleSheets mPlugin;
   private static SpreadsheetsOperations mInstance;
 
@@ -25,17 +24,22 @@ public class SpreadsheetsOperations extends Operations {
     return mInstance;
   }
 
-  public Runnable batchUpdate(final JSONArray params) {
-    return new Runnable() {
+  public Operation batchUpdate(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
-        // TODO: implement batcUpdate and request interfaces
-        mPlugin.getCallbackContext().error("not implemented yet");
+        mPlugin.handle(
+            this,
+            context,
+            new UnsupportedOperationException(
+                "SpreadsheetsOperations' batchUpdate has not been implemented yet"));
       }
     };
   }
 
-  public Runnable create(final JSONArray params) {
-    return new Runnable() {
+  public Operation create(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           JSONObject spreadsheetJson = params.getJSONObject(0);
@@ -59,7 +63,7 @@ public class SpreadsheetsOperations extends Operations {
           if (!isCordovaNullable(spreadsheetAutoRecalc)) {
             properties.setAutoRecalc(spreadsheetAutoRecalc);
           }
-          
+
           if (!isCordovaNullable(spreadsheetTimeZone)) {
             properties.setTimeZone(spreadsheetTimeZone);
           }
@@ -69,19 +73,18 @@ public class SpreadsheetsOperations extends Operations {
 
           Spreadsheet response = request.execute();
 
-          mPlugin.getCallbackContext().success(response.toString());
+          context.success(response.toString());
 
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable get(final JSONArray params) {
-    return new Runnable() {
+  public Operation get(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -97,22 +100,25 @@ public class SpreadsheetsOperations extends Operations {
 
           Spreadsheet response = request.execute();
 
-          mPlugin.getCallbackContext().success(response.toString());
+          context.success(response.toString());
 
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable getByDataFilter(final JSONArray params) {
-    //TODO implement this.
-    return new Runnable() {
+  public Operation getByDataFilter(final JSONArray params, final CallbackContext context) {
+    // TODO implement this.
+    return new Operation() {
+      @Override
       public void run() {
-        mPlugin.getCallbackContext().error("Not implemented yet...");
+        mPlugin.handle(
+            this,
+            context,
+            new UnsupportedOperationException(
+                "SpreadsheetsOperations' getByDataFilter has not been implemented yet"));
       }
     };
   }

--- a/src/android/UserNotSignedIn.java
+++ b/src/android/UserNotSignedIn.java
@@ -1,0 +1,9 @@
+package org.sumaq.plugins.googlesheets;
+
+public class UserNotSignedIn extends Exception {
+  private static final String MESSAGE = "The user has not signed in";
+
+  public UserNotSignedIn() {
+    super(UserNotSignedIn.MESSAGE);
+  }
+}

--- a/src/android/ValuesOperations.java
+++ b/src/android/ValuesOperations.java
@@ -11,14 +11,13 @@ import com.google.api.services.sheets.v4.model.ClearValuesRequest;
 import com.google.api.services.sheets.v4.model.ClearValuesResponse;
 import com.google.api.services.sheets.v4.model.UpdateValuesResponse;
 import com.google.api.services.sheets.v4.model.ValueRange;
-import com.google.api.client.googleapis.extensions.android.gms.auth.UserRecoverableAuthIOException;
-import java.lang.Runnable;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
-public class ValuesOperations extends Operations {
+public class ValuesOperations extends OperationsProvider {
   private GoogleSheets mPlugin;
   private static ValuesOperations mInstance;
   public static String STR_DEFAULT_MAJOR_DIMENSION_OPT = "ROWS";
@@ -38,8 +37,9 @@ public class ValuesOperations extends Operations {
     return mInstance;
   }
 
-  public Runnable append(final JSONArray params) {
-    return new Runnable() {
+  public Operation append(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -64,28 +64,27 @@ public class ValuesOperations extends Operations {
           Sheets sheetsService = mPlugin.getService();
           Sheets.Spreadsheets.Values.Append request =
               sheetsService.spreadsheets().values().append(spreadsheetId, range, requestBody);
-          if (!isCordovaNullable(valueInputOption)) {
+          if (isCordovaNullable(valueInputOption)) {
             valueInputOption = ValuesOperations.DEFAULT_VALUE_INPUT_OPTION;
           }
-          if (!isCordovaNullable(insertDataOption)) {
+          if (isCordovaNullable(insertDataOption)) {
             insertDataOption = ValuesOperations.DEFAULT_INSERT_DATA_OPTION;
           }
           request.setValueInputOption(valueInputOption);
           request.setInsertDataOption(insertDataOption);
 
           AppendValuesResponse response = request.execute();
-          mPlugin.getCallbackContext().success(response.toString());
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+          context.success(response.toString());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable batchClear(final JSONArray params) {
-    return new Runnable() {
+  public Operation batchClear(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -104,31 +103,35 @@ public class ValuesOperations extends Operations {
               sheetsService.spreadsheets().values().batchClear(spreadsheetId, requestBody);
 
           BatchClearValuesResponse response = request.execute();
-          mPlugin.getCallbackContext().success(response.toString());
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+          context.success(response.toString());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable batchClearByDataFilter(final JSONArray params) {
-    return new Runnable() {
+  public Operation batchClearByDataFilter(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         /*TODO: implement data filter mechanisms.
         try {
-        } catch (Exception e) {
+        } catch (Exception exception) {
         }
         */
-        mPlugin.getCallbackContext().error("Not implemented yet...");
+        mPlugin.handle(
+            this,
+            context,
+            new UnsupportedOperationException(
+                "ValuesOperations' batchClearByDataFilter has not been implemented yet"));
       }
     };
   }
 
-  public Runnable batchGet(final JSONArray params) {
-    return new Runnable() {
+  public Operation batchGet(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -136,7 +139,7 @@ public class ValuesOperations extends Operations {
           String majorDimension = params.getString(2);
           String valueRenderOption = params.getString(3);
           String dateTimeRenderOption = params.getString(4);
-          List<String> rangesList = new ArrayList();
+          List<String> rangesList = new ArrayList<String>();
 
           for (int i = 0; i < spreadsheetRanges.length(); i++) {
             rangesList.add(spreadsheetRanges.getString(i));
@@ -153,31 +156,35 @@ public class ValuesOperations extends Operations {
             request.setDateTimeRenderOption(dateTimeRenderOption);
           }
           BatchGetValuesResponse response = request.execute();
-          mPlugin.getCallbackContext().success(response.toString());
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+          context.success(response.toString());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable batchGetByDataFilter(final JSONArray params) {
-    return new Runnable() {
+  public Operation batchGetByDataFilter(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         /* TODO: implement data filter mechanisms.
         try {
-        } catch (Exception e) {
+        } catch (Exception exception) {
         }
         */
-        mPlugin.getCallbackContext().error("Not implemented yet");
+        mPlugin.handle(
+            this,
+            context,
+            new UnsupportedOperationException(
+                "ValuesOperations' batchClearByDataFilter has not been implemented yet"));
       }
     };
   }
 
-  public Runnable batchUpdate(final JSONArray params) {
-    return new Runnable() {
+  public Operation batchUpdate(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -215,19 +222,18 @@ public class ValuesOperations extends Operations {
 
           BatchUpdateValuesResponse response = request.execute();
 
-          mPlugin.getCallbackContext().success(response.toString());
+          context.success(response.toString());
 
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable clear(final JSONArray params) {
-    return new Runnable() {
+  public Operation clear(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -240,18 +246,17 @@ public class ValuesOperations extends Operations {
               sheetsService.spreadsheets().values().clear(spreadsheetId, range, requestBody);
 
           ClearValuesResponse response = request.execute();
-          mPlugin.getCallbackContext().success(response.toString());
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().success(e.getMessage());
+          context.success(response.toString());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable get(final JSONArray params) {
-    return new Runnable() {
+  public Operation get(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -262,18 +267,17 @@ public class ValuesOperations extends Operations {
           request.setValueRenderOption(ValuesOperations.DEFAULT_VALUE_RENDER_OPTION);
 
           ValueRange response = request.execute();
-          mPlugin.getCallbackContext().success(response.toString());
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+          context.success(response.toString());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };
   }
 
-  public Runnable update(final JSONArray params) {
-    return new Runnable() {
+  public Operation update(final JSONArray params, final CallbackContext context) {
+    return new Operation() {
+      @Override
       public void run() {
         try {
           String spreadsheetId = params.getString(0);
@@ -299,11 +303,9 @@ public class ValuesOperations extends Operations {
           request.setValueInputOption(ValuesOperations.DEFAULT_VALUE_INPUT_OPTION);
 
           UpdateValuesResponse response = request.execute();
-          mPlugin.getCallbackContext().success(response.toString());
-        } catch (UserRecoverableAuthIOException authExcept) {
-          mPlugin.requestAuthorization(authExcept, this);
-        } catch (Exception e) {
-          mPlugin.getCallbackContext().error(e.getMessage());
+          context.success(response.toString());
+        } catch (Exception exception) {
+          mPlugin.handle(this, context, exception);
         }
       }
     };


### PR DESCRIPTION
* The GoogleSheets object no longer keeps a reference to the latest
CallbackContext object sent to it's exec method
* The signIn method has been moved out from GoogleSheets objet into the new
AccountOperations object.
* The operations now inherit from the Operation abstract class, which
implements the Runnable interface.
* There is now a new exception type called UserNotSignedIn which is
thrown every time an operation is queried without a user being signed
in.

The GoogleSheets object has been keeping a reference to the latest
CallbackContext sent to the exec method, that's not thread safe since
any thread could make changes on a CallbackContext that wasn't its own.

Every operation related with authentication, authorization and any other
account-related activity has been put into the AccountOperations class.

Closes SumaqIdeas/cordova-plugin-google-sheets#22